### PR TITLE
feat: Add service type selection with Discord Bot and Minecraft hosting flows

### DIFF
--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -5,7 +5,9 @@ import { Card, CardContent } from "@/components/ui/card"
 import { FormProgress } from '@/components/plans/FormProgress'
 import { RegionStep } from '@/components/plans/RegionStep'
 import { PlanStep } from '@/components/plans/PlanStep'
+import TypeStep from '@/components/plans/TypeStep'
 import ServerTypeStep from '@/components/plans/ServerTypeStep'
+import DiscordRuntimeStep from '@/components/plans/DiscordRuntimeStep'
 import CPURamStep from '@/components/plans/CPURamStep'
 import StorageStep from '@/components/plans/StorageStep'
 import { CheckoutStep } from '@/components/plans/CheckoutStep'
@@ -16,17 +18,21 @@ import {
   StepProps,
   Region,
   PlanType,
+  ServiceType,
   RAM,
   CPUThreads,
   Storage,
-  ServerType
+  ServerType,
+  DiscordRuntime
 } from '@/components/plans/types'
 import { useIsMobile } from '@/hooks/use-mobile'
 
 const STEPS = {
   region: RegionStep,
   plan: PlanStep,
+  type: TypeStep,
   server: ServerTypeStep,
+  runtime: DiscordRuntimeStep,
   cpuram: CPURamStep,
   storage: StorageStep,
   checkout: CheckoutStep
@@ -38,7 +44,8 @@ function getInitialState(): FormState {
     return {
       region: 'india',
       planType: 'budget',
-      serverType: 'PaperMC',
+      serviceType: undefined,
+      serverType: undefined,
       cpuThreads: '2',
       ram: '4',
       storage: '50',
@@ -51,7 +58,9 @@ function getInitialState(): FormState {
   return {
     region: (params.get('region') as Region) || 'india',
     planType: (params.get('plan') as PlanType) || 'budget',
-    serverType: (params.get('server') as ServerType) || 'PaperMC',
+    serviceType: (params.get('service') as ServiceType) || undefined,
+    serverType: (params.get('server') as ServerType) || undefined,
+    discordRuntime: (params.get('runtime') as DiscordRuntime) || undefined,
     cpuThreads: (params.get('cpu') as CPUThreads) || '2',
     ram: (params.get('ram') as RAM) || '4',
     storage: (params.get('storage') as Storage) || '50',
@@ -59,16 +68,15 @@ function getInitialState(): FormState {
   }
 }
 
-// Get initial step from URL or start at region
+// Get initial step from URL or start at type
 function getInitialStep(): FormStep {
-  if (typeof window === 'undefined') return 'region'
+  if (typeof window === 'undefined') return 'type'
   const params = new URLSearchParams(window.location.search)
   const step = params.get('step') as FormStep | null
-  return step && Object.keys(STEPS).includes(step) ? step : 'region'
+  return step && Object.keys(STEPS).includes(step) ? step : 'type'
 }
 
-// Define step order for navigation
-const STEP_ORDER: FormStep[] = ['region', 'plan', 'server', 'cpuram', 'storage', 'checkout']
+// Define step order for navigation - will be dynamically determined based on service type
 
 export default function PlansPage() {
   const isMobile = useIsMobile()
@@ -81,7 +89,9 @@ export default function PlansPage() {
     params.set('step', step)
     if (state.region) params.set('region', state.region)
     if (state.planType) params.set('plan', state.planType)
+    if (state.serviceType) params.set('service', state.serviceType)
     if (state.serverType) params.set('server', state.serverType)
+    if (state.discordRuntime) params.set('runtime', state.discordRuntime)
     if (state.cpuThreads) params.set('cpu', state.cpuThreads)
     if (state.ram) params.set('ram', state.ram)
     if (state.storage) params.set('storage', state.storage)
@@ -112,20 +122,33 @@ export default function PlansPage() {
     })
   }
 
+  const getStepOrder = (): FormStep[] => {
+    const baseSteps: FormStep[] = ['type', 'region', 'plan']
+    
+    if (state.serviceType === 'minecraft') {
+      return [...baseSteps, 'server', 'cpuram', 'storage', 'checkout']
+    } else if (state.serviceType === 'discord-bot') {
+      return ['type', 'runtime', 'checkout']
+    }
+    
+    return baseSteps
+  }
+
   const handleNext = () => {
-    const currentIndex = STEP_ORDER.indexOf(step)
+    const stepOrder = getStepOrder()
+    const currentIndex = stepOrder.indexOf(step)
     
     if (currentIndex === -1 || !StepValidators[step].canProceed(state)) {
       return
     }
 
-    // Skip storage step for US East
-    if (state.region === 'us-east' && STEP_ORDER[currentIndex + 1] === 'storage') {
-      setStep('checkout')
-      return
-      }
+    let nextStep = stepOrder[currentIndex + 1]
+    
+    // Skip storage step for US East in minecraft flow
+    if (state.region === 'us-east' && state.serviceType === 'minecraft' && nextStep === 'storage') {
+      nextStep = 'checkout'
+    }
 
-    const nextStep = STEP_ORDER[currentIndex + 1]
     if (nextStep) {
       setStep(nextStep)
       // Scroll to top on mobile when changing steps
@@ -136,14 +159,19 @@ export default function PlansPage() {
   }
 
   const handleBack = () => {
-    const currentIndex = STEP_ORDER.indexOf(step)
-      if (state.region === 'us-east' && STEP_ORDER[currentIndex - 1] === 'storage') {
-          setStep('cpuram')
+    const stepOrder = getStepOrder()
+    const currentIndex = stepOrder.indexOf(step)
+    
+    if (currentIndex > 0) {
+      let prevStep = stepOrder[currentIndex - 1]
+      
+      // Skip storage step for US East in minecraft flow when going back
+      if (state.region === 'us-east' && state.serviceType === 'minecraft' && prevStep === 'storage') {
+        prevStep = stepOrder[currentIndex - 2] || stepOrder[0]
       }
-      else if (currentIndex > 0) {
-          setStep(STEP_ORDER[currentIndex - 1])
-
-
+      
+      setStep(prevStep)
+      
       // Scroll to top on mobile when changing steps
       if (isMobile) {
         window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -170,7 +198,7 @@ export default function PlansPage() {
                 state={state}
                 onUpdate={handleUpdateState}
                 onNext={handleNext}
-                onBack={step !== 'region' ? handleBack : undefined}
+                onBack={step !== 'type' ? handleBack : undefined}
                 isValid={isValid}
                 availableOptions={availableOptions}
               />

--- a/src/components/plans/CheckoutStep.tsx
+++ b/src/components/plans/CheckoutStep.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Button } from "@/components/ui/button"
-import { StepProps, formatPrice, RAM_PRICING, STORAGE_PRICING, generateCheckoutUrl, calculateComponentPrice, getCPUThreadPrice,  } from "./types"
+import { StepProps, formatPrice, RAM_PRICING, STORAGE_PRICING, generateCheckoutUrl, calculateComponentPrice, getCPUThreadPrice, DISCORD_BOT_PRICE } from "./types"
 import { Card, CardContent } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -15,23 +15,30 @@ export function CheckoutStep({ state, onUpdate, onBack }: StepProps) {
   const [billingPeriod, setBillingPeriod] = React.useState(state.billingPeriod)
   
   // Destructure state for useMemo dependencies
-  const { region, planType, serverType, ram, storage, cpuThreads } = state
+  const { region, planType, serviceType, serverType, discordRuntime, ram, storage, cpuThreads } = state
 
   React.useEffect(() => {
     setBillingPeriod(state.billingPeriod)
   }, [state.billingPeriod])
 
   const isUSEast = region === 'us-east'
-  const priceBreakdown: PriceBreakdownItem[] = [
+  const isDiscordBot = serviceType === 'discord-bot'
+  
+  const priceBreakdown: PriceBreakdownItem[] = isDiscordBot ? [
+    {
+      label: 'Discord Bot Hosting',
+      monthlyPrice: DISCORD_BOT_PRICE
+    }
+  ] : [
     ...([
       {
         label: `CPU (${cpuThreads} Thread${cpuThreads === '1' ? '' : 's'})`,
-        monthlyPrice: cpuThreads ? getCPUThreadPrice(region, cpuThreads) : 0
+        monthlyPrice: cpuThreads ? getCPUThreadPrice(region, cpuThreads, serviceType) : 0
       }
     ]),
     {
       label: `RAM (${ram}GB)${isUSEast ? ' ($0.75/GB)' : ''}`,
-      monthlyPrice: RAM_PRICING(region, ram)
+      monthlyPrice: RAM_PRICING(region, ram, serviceType)
     },
     ...(isUSEast ? [] : [
       {
@@ -61,13 +68,15 @@ export function CheckoutStep({ state, onUpdate, onBack }: StepProps) {
       generateCheckoutUrl({
         region,
         planType,
+        serviceType,
         serverType,
+        discordRuntime,
         ram,
         storage,
         cpuThreads,
         billingPeriod,
       }),
-    [region, planType, serverType, ram, storage, cpuThreads, billingPeriod]
+    [region, planType, serviceType, serverType, discordRuntime, ram, storage, cpuThreads, billingPeriod]
   )
 
   return (
@@ -87,8 +96,34 @@ export function CheckoutStep({ state, onUpdate, onBack }: StepProps) {
               <span className="text-gray-600">Plan:</span>
               <span className="font-medium">{planType}</span>
               
-              <span className="text-gray-600">Server Type:</span>
-              <span className="font-medium">{serverType}</span>
+              <span className="text-gray-600">Service Type:</span>
+              <span className="font-medium">
+                {serviceType === 'minecraft' ? 'Minecraft Server' : 'Discord Bot'}
+              </span>
+              
+              {serviceType === 'minecraft' && serverType && (
+                <>
+                  <span className="text-gray-600">Server Type:</span>
+                  <span className="font-medium">{serverType}</span>
+                </>
+              )}
+              
+              {serviceType === 'discord-bot' && discordRuntime && (
+                <>
+                  <span className="text-gray-600">Runtime:</span>
+                  <span className="font-medium">{discordRuntime === 'nodejs' ? 'Node.js' : 'Python'}</span>
+                  <span className="text-gray-600">Region:</span>
+                  <span className="font-medium">America (US East)</span>
+                  <span className="text-gray-600">CPU:</span>
+                  <span className="font-medium">0.5 Threads</span>
+                  <span className="text-gray-600">RAM:</span>
+                  <span className="font-medium">512 MB</span>
+                  <span className="text-gray-600">Storage:</span>
+                  <span className="font-medium">3 GB NVMe SSD</span>
+                  <span className="text-gray-600">Hardware:</span>
+                  <span className="font-medium">Ampere® Altra®</span>
+                </>
+              )}
             </div>
 
             <Separator />
@@ -119,64 +154,75 @@ export function CheckoutStep({ state, onUpdate, onBack }: StepProps) {
 
               <Separator className="my-4" />
 
-              <div className="space-y-4">
-                <h3 className="font-medium">Billing Period</h3>
-                <RadioGroup
-                  value={billingPeriod}
-                  onValueChange={handleBillingPeriodChange}
-                  className="flex flex-col space-y-3"
-                >
-                  <div className="flex items-center space-x-3">
-                    <RadioGroupItem value="monthly" id="monthly" />
-                    <Label htmlFor="monthly" className="flex flex-col">
-                      <span>Monthly</span>
-                      <span className="text-sm text-gray-600">
-                        {formatPrice(monthlySubtotal)} per month
-                      </span>
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-3">
-                    <RadioGroupItem value="quarterly" id="quarterly" />
-                    <Label htmlFor="quarterly" className="flex flex-col">
-                      <span>Quarterly (10% off each component)</span>
-                      <span className="text-sm text-gray-600">
-                        {formatPrice(discountedSubtotal)} per month ({formatPrice(periodTotal)} billed every 3 months)
-                      </span>
-                    </Label>
-                  </div>
-                </RadioGroup>
-              </div>
-
-              <Separator className="my-4" />
-
-              {billingPeriod === 'quarterly' ? (
-                <>
-                  <div className="flex justify-between text-sm">
-                    <span className="text-gray-600">Monthly Base Price</span>
-                    <span className="text-gray-400 line-through">{formatPrice(monthlySubtotal)}</span>
-                  </div>
-                  <div className="flex justify-between text-sm text-green-600">
-                    <span>Discounted Monthly Price (10% off)</span>
-                    <span>{formatPrice(discountedSubtotal)}</span>
-                  </div>
-                </>
-              ) : (
-                <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Monthly Price</span>
-                  <span>{formatPrice(monthlySubtotal)}</span>
+              {!isDiscordBot && (
+                <div className="space-y-4">
+                  <h3 className="font-medium">Billing Period</h3>
+                  <RadioGroup
+                    value={billingPeriod}
+                    onValueChange={handleBillingPeriodChange}
+                    className="flex flex-col space-y-3"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <RadioGroupItem value="monthly" id="monthly" />
+                      <Label htmlFor="monthly" className="flex flex-col">
+                        <span>Monthly</span>
+                        <span className="text-sm text-gray-600">
+                          {formatPrice(monthlySubtotal)} per month
+                        </span>
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-3">
+                      <RadioGroupItem value="quarterly" id="quarterly" />
+                      <Label htmlFor="quarterly" className="flex flex-col">
+                        <span>Quarterly (10% off each component)</span>
+                        <span className="text-sm text-gray-600">
+                          {formatPrice(discountedSubtotal)} per month ({formatPrice(periodTotal)} billed every 3 months)
+                        </span>
+                      </Label>
+                    </div>
+                  </RadioGroup>
                 </div>
               )}
 
-              <div className="flex justify-between font-medium text-base pt-2">
-                <span>Total {billingPeriod === 'quarterly' ? '(3 months)' : '(monthly)'}</span>
-                <span>{formatPrice(periodTotal)}</span>
-              </div>
+              <Separator className="my-4" />
 
-              {billingPeriod === 'quarterly' && (
-                <div className="flex justify-between text-sm text-green-600">
-                  <span>You save</span>
-                  <span>{formatPrice((monthlySubtotal - discountedSubtotal) * 3)} over 3 months</span>
+              {isDiscordBot ? (
+                <div className="flex justify-between font-medium text-base pt-2">
+                  <span>Total (monthly)</span>
+                  <span>{formatPrice(DISCORD_BOT_PRICE)}</span>
                 </div>
+              ) : (
+                <>
+                  {billingPeriod === 'quarterly' ? (
+                    <>
+                      <div className="flex justify-between text-sm">
+                        <span className="text-gray-600">Monthly Base Price</span>
+                        <span className="text-gray-400 line-through">{formatPrice(monthlySubtotal)}</span>
+                      </div>
+                      <div className="flex justify-between text-sm text-green-600">
+                        <span>Discounted Monthly Price (10% off)</span>
+                        <span>{formatPrice(discountedSubtotal)}</span>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex justify-between text-sm">
+                      <span className="text-gray-600">Monthly Price</span>
+                      <span>{formatPrice(monthlySubtotal)}</span>
+                    </div>
+                  )}
+
+                  <div className="flex justify-between font-medium text-base pt-2">
+                    <span>Total {billingPeriod === 'quarterly' ? '(3 months)' : '(monthly)'}</span>
+                    <span>{formatPrice(periodTotal)}</span>
+                  </div>
+
+                  {billingPeriod === 'quarterly' && (
+                    <div className="flex justify-between text-sm text-green-600">
+                      <span>You save</span>
+                      <span>{formatPrice((monthlySubtotal - discountedSubtotal) * 3)} over 3 months</span>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/src/components/plans/DiscordRuntimeStep.tsx
+++ b/src/components/plans/DiscordRuntimeStep.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { DiscordRuntime, StepProps } from './types'
+
+const RUNTIME_OPTIONS: { value: DiscordRuntime; label: string; description: string }[] = [
+  {
+    value: 'nodejs',
+    label: 'Node.js',
+    description: 'JavaScript runtime built on Chrome\'s V8 engine'
+  },
+  {
+    value: 'python',
+    label: 'Python',
+    description: 'High-level programming language for bot development'
+  }
+]
+
+export default function DiscordRuntimeStep({ state, onUpdate, onNext, onBack, isValid }: StepProps) {
+  const handleRuntimeSelect = (discordRuntime: DiscordRuntime) => {
+    onUpdate({ discordRuntime })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <h2 className="text-xl font-semibold">Choose Your Runtime</h2>
+        <p className="text-muted-foreground">
+          Select the programming language runtime for your Discord bot
+        </p>
+      </div>
+
+      <div className="grid gap-4">
+        {RUNTIME_OPTIONS.map((option) => (
+          <Card
+            key={option.value}
+            className={`cursor-pointer transition-all ${
+              state.discordRuntime === option.value
+                ? 'ring-2 ring-primary bg-primary/5'
+                : 'hover:shadow-md'
+            }`}
+            onClick={() => handleRuntimeSelect(option.value)}
+          >
+            <CardContent className="p-4">
+              <div className="flex items-center space-x-4">
+                <div className="flex-1">
+                  <h3 className="font-medium">{option.label}</h3>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {option.description}
+                  </p>
+                </div>
+                <div className={`w-4 h-4 rounded-full border-2 ${
+                  state.discordRuntime === option.value
+                    ? 'bg-primary border-primary'
+                    : 'border-muted-foreground'
+                }`} />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="flex justify-between pt-4">
+        {onBack && (
+          <Button variant="outline" onClick={onBack}>
+            Back
+          </Button>
+        )}
+        <Button 
+          onClick={onNext} 
+          disabled={!isValid}
+          className={!onBack ? 'ml-auto' : ''}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/plans/FormProgress.tsx
+++ b/src/components/plans/FormProgress.tsx
@@ -1,28 +1,54 @@
 import * as React from 'react'
-import { FormStep } from "./types"
+import { FormStep, ServiceType } from "./types"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 interface Props {
   currentStep: FormStep
-  state?: { region?: string }
+  state?: { region?: string; serviceType?: ServiceType }
 }
 
-const ALL_STEPS: { step: FormStep; label: string }[] = [
-  { step: 'region', label: 'Location' },
-  { step: 'plan', label: 'Plan' },
-  { step: 'server', label: 'Server Type' },
-  { step: 'cpuram', label: 'CPU/RAM' },
-  { step: 'storage', label: 'Storage' },
-  { step: 'checkout', label: 'Checkout' }
-]
+const getStepsForServiceType = (serviceType?: ServiceType, region?: string, currentStep?: FormStep): { step: FormStep; label: string }[] => {
+  // If on type step, only show the type step
+  if (currentStep === 'type') {
+    return [{ step: 'type' as FormStep, label: 'Type' }]
+  }
+  
+  const baseSteps = [
+    { step: 'type' as FormStep, label: 'Type' },
+    { step: 'region' as FormStep, label: 'Location' },
+    { step: 'plan' as FormStep, label: 'Plan' }
+  ]
+  
+  if (serviceType === 'minecraft') {
+    const minecraftSteps = [
+      { step: 'server' as FormStep, label: 'Server Type' },
+      { step: 'cpuram' as FormStep, label: 'CPU/RAM' },
+      { step: 'storage' as FormStep, label: 'Storage' },
+      { step: 'checkout' as FormStep, label: 'Checkout' }
+    ]
+    
+    // Skip storage for US East
+    if (region === 'us-east') {
+      return [...baseSteps, ...minecraftSteps.filter(step => step.step !== 'storage')]
+    }
+    
+    return [...baseSteps, ...minecraftSteps]
+  } else if (serviceType === 'discord-bot') {
+    return [
+      { step: 'type' as FormStep, label: 'Type' },
+      { step: 'runtime' as FormStep, label: 'Runtime' },
+      { step: 'checkout' as FormStep, label: 'Checkout' }
+    ]
+  }
+  
+  // Default to base steps if no service type selected yet
+  return baseSteps
+}
 
 export function FormProgress({ currentStep, state }: Props) {
   const STEPS = React.useMemo(() => {
-    if (state?.region === 'us-east') {
-      return ALL_STEPS.filter(step => step.step !== 'storage')
-    }
-    return ALL_STEPS
-  }, [state?.region])
+    return getStepsForServiceType(state?.serviceType, state?.region, currentStep)
+  }, [state?.serviceType, state?.region, currentStep])
   const isMobile = useIsMobile()
   const currentIndex = STEPS.findIndex(s => s.step === currentStep)
   

--- a/src/components/plans/TypeStep.tsx
+++ b/src/components/plans/TypeStep.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { ServiceType, StepProps } from './types'
+
+const SERVICE_OPTIONS: { value: ServiceType; label: string; description: string }[] = [
+  {
+    value: 'minecraft',
+    label: 'Minecraft Server',
+    description: 'Host your Minecraft server with various mod loaders and plugins'
+  },
+  {
+    value: 'discord-bot',
+    label: 'Discord Bot',
+    description: 'Host your Discord bot with Node.js or Python runtime'
+  }
+]
+
+export default function TypeStep({ state, onUpdate, onNext, onBack, isValid }: StepProps) {
+  const handleServiceTypeSelect = (serviceType: ServiceType) => {
+    if (serviceType === 'discord-bot') {
+      // Set default values for Discord Bot to skip intermediate steps
+      onUpdate({ 
+        serviceType,
+        region: 'us-east',
+        planType: 'budget',
+        ram: '0.5',
+        cpuThreads: '0.5',
+        storage: '3',
+        billingPeriod: 'monthly',
+        // Reset dependent fields when changing service type
+        serverType: undefined,
+        discordRuntime: undefined
+      })
+    } else {
+      onUpdate({ 
+        serviceType,
+        // Reset dependent fields when changing service type
+        serverType: undefined,
+        discordRuntime: undefined
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <h2 className="text-xl font-semibold">Choose Your Service Type</h2>
+        <p className="text-muted-foreground">
+          Select what type of service you want to host
+        </p>
+      </div>
+
+      <div className="grid gap-4">
+        {SERVICE_OPTIONS.map((option) => (
+          <Card
+            key={option.value}
+            className={`cursor-pointer transition-all ${
+              state.serviceType === option.value
+                ? 'ring-2 ring-primary bg-primary/5'
+                : 'hover:shadow-md'
+            }`}
+            onClick={() => handleServiceTypeSelect(option.value)}
+          >
+            <CardContent className="p-4">
+              <div className="flex items-center space-x-4">
+                <div className="flex-1">
+                  <h3 className="font-medium">{option.label}</h3>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {option.description}
+                  </p>
+                </div>
+                <div className={`w-4 h-4 rounded-full border-2 ${
+                  state.serviceType === option.value
+                    ? 'bg-primary border-primary'
+                    : 'border-muted-foreground'
+                }`} />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="flex justify-between pt-4">
+        {onBack && (
+          <Button variant="outline" onClick={onBack}>
+            Back
+          </Button>
+        )}
+        <Button 
+          onClick={onNext} 
+          disabled={!isValid}
+          className={!onBack ? 'ml-auto' : ''}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Implement service type selection as the first step in the hosting onboarding flow
- Add separate optimized flows for Discord Bot hosting vs Minecraft server hosting
- Integrate Discord Bot specific pricing and checkout configuration

## Changes Made

### New Flow Architecture
- **Type Selection**: New first step to choose between Discord Bot and Minecraft hosting
- **Discord Bot Flow**: Simplified 3-step process (Type → Runtime → Checkout)
- **Minecraft Flow**: Full configuration process (Type → Location → Plan → Server → CPU/RAM → Storage → Checkout)

### Discord Bot Hosting Features
- **Fixed Configuration**: 
  - Region: US East (America)
  - CPU: 0.5 threads
  - RAM: 512 MB
  - Storage: 3 GB NVMe SSD
  - Hardware: Ampere® Altra®
- **Pricing**: Flat rate $1.50/month (monthly billing only)
- **Runtime Selection**: Choose between Node.js or Python
- **Checkout Integration**: Runtime-specific URLs (Node.js: config/16, Python: config/17)

### Technical Implementation
- Add `TypeStep` and `DiscordRuntimeStep` components
- Update `FormProgress` for dynamic step visualization
- Extend type system with `ServiceType` and `DiscordRuntime`
- Add Discord Bot pricing logic and checkout URL generation
- Update existing components to handle new flow patterns

### User Experience
- Progressive disclosure: Only show relevant steps based on service type
- Streamlined Discord Bot setup with sensible defaults
- Maintain existing Minecraft server customization experience

## Test Plan

- [x] Build succeeds without errors
- [x] Linting passes
- [x] Test Discord Bot flow: Type → Runtime → Checkout
- [x] Test Minecraft flow: Type → Location → Plan → Server → CPU/RAM → Storage → Checkout
- [x] Verify Discord Bot checkout URLs redirect correctly
- [x] Test form navigation and back button functionality
- [x] Verify pricing calculations for both service types

🤖 Generated with [Claude Code](https://claude.ai/code)